### PR TITLE
Move search form to navbar, display on index + show only

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,17 +11,7 @@
       <div class="hero-text col col-lg-12">
         <h1> <%= link_to 'MealVille', events_path, class:"text-decoration-none text-white" %> </h1>
         <div class="mb-3">
-          <%= form_tag events_path, method: :get, class:"input-group row m-0" do %>
-          <div class="col-12 col-md-7" style="padding: 0px!important">
-            <%= text_field_tag :query, params[:query], class: "form-control bg-light bg-gradient bg-opacity-10 text-white", placeholder: "Search by an Event name, a Cuisine or a Location" %>
-          </div>
-          <div class="col-12 col-md-3" style="padding: 0px!important">
-            <%= text_field_tag :dates, params[:dates], class: "form-control bg-light bg-gradient bg-opacity-10 text-white", placeholder: "Search by a date range", data: {controller: 'flatpickr', flatpickr_target: 'dates'} %>
-          </div>
-          <div class="col-12 col-md-2" style="padding: 0px!important">
-            <div class="input-group-append"><%= submit_tag "Search", class:"btn btn-outline-light w-100" %></div>
-          </div>
-          <% end %>
+          <%= render 'shared/search_form' %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,8 +7,14 @@
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-
+      <% if (params[:controller] == "events" && (params[:action] == "index" || params[:action] == "show")) %>
+        <div class="d-flex justify-content-center w-50">
+          <%= render 'shared/search_form' %>
+        </div>
+      <% end %>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
           <% if !current_user.host %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_tag events_path, method: :get, class:"input-group row m-0" do %>
+  <div class="col-12 col-md-7" style="padding: 0px!important">
+    <%= text_field_tag :query, params[:query], class: "form-control bg-light bg-gradient bg-opacity-10 text-white", placeholder: "Search by an Event name, a Cuisine or a Location" %>
+  </div>
+  <div class="col-12 col-md-3" style="padding: 0px!important">
+    <%= text_field_tag :dates, params[:dates], class: "form-control bg-light bg-gradient bg-opacity-10 text-white", placeholder: "Search by a date range", data: {controller: 'flatpickr', flatpickr_target: 'dates'} %>
+  </div>
+  <div class="col-12 col-md-2" style="padding: 0px!important">
+    <div class="input-group-append"><%= submit_tag "Search", class:"btn btn-outline-light w-100" %></div>
+  </div>
+<% end %>


### PR DESCRIPTION
Extracted search form as partial to make it reusable.
Including search form in navbar, only displays in index and show page.